### PR TITLE
Lighten org-block begin/end foreground color

### DIFF
--- a/doom-rose-pine-dawn-theme.el
+++ b/doom-rose-pine-dawn-theme.el
@@ -202,8 +202,8 @@
     ;; org <built-in>
     (org-block :background (doom-blend yellow bg 0.04) :extend t)
     (org-block-background :background (doom-blend yellow bg 0.04))
-    (org-block-begin-line :background (doom-blend yellow bg 0.08) :extend t)
-    (org-block-end-line :background (doom-blend yellow bg 0.08) :extend t)
+    (org-block-begin-line :background (doom-blend yellow bg 0.08) :foreground comments :extend t)
+    (org-block-end-line :background (doom-blend yellow bg 0.08) :foreground comments :extend t)
     (org-level-1 :foreground gold)
     (org-level-2 :foreground rose)
     (org-level-3 :foreground pine)

--- a/doom-rose-pine-moon-theme.el
+++ b/doom-rose-pine-moon-theme.el
@@ -209,8 +209,8 @@
     ;; org <built-in>
     (org-block :background (doom-blend yellow bg 0.04) :extend t)
     (org-block-background :background (doom-blend yellow bg 0.04))
-    (org-block-begin-line :background (doom-blend yellow bg 0.08) :extend t)
-    (org-block-end-line :background (doom-blend yellow bg 0.08) :extend t)
+    (org-block-begin-line :background (doom-blend yellow bg 0.08) :foreground comments :extend t)
+    (org-block-end-line :background (doom-blend yellow bg 0.08) :foreground comments :extend t)
     (org-level-1 :foreground gold)
     (org-level-2 :foreground rose)
     (org-level-3 :foreground pine)

--- a/doom-rose-pine-theme.el
+++ b/doom-rose-pine-theme.el
@@ -208,8 +208,8 @@
     ;; org <built-in>
     (org-block :background (doom-blend yellow bg 0.04) :extend t)
     (org-block-background :background (doom-blend yellow bg 0.04))
-    (org-block-begin-line :background (doom-blend yellow bg 0.08) :extend t)
-    (org-block-end-line :background (doom-blend yellow bg 0.08) :extend t)
+    (org-block-begin-line :background (doom-blend yellow bg 0.08) :foreground comments :extend t)
+    (org-block-end-line :background (doom-blend yellow bg 0.08) :foreground comments :extend t)
     (org-level-1 :foreground gold)
     (org-level-2 :foreground rose)
     (org-level-3 :foreground pine)


### PR DESCRIPTION
Of course, this is purely a matter of taste, so don't be afraid to decline this PR. But I find that if the color of the begin/end lines matches the normal foreground of the text, the blocks feel real busy.