### PR TITLE
Updated doom config directory to the new format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCEPATH = .
-TARGETPATH = ~/.doom.d/themes/
+TARGETPATH = ~/.config/doom/themes/
 
 install:
 	mkdir -p $(TARGETPATH)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,20 @@
 All natural pine, faux fur and a bit of soho vibes for the classy minimalist.
 
 # How to install
-1. Clone or download this repo
-2. `make install` to copy the themes to `~/.config/.doom/themes/`
-3. Update your `config.el`
-    - `(setq doom-theme 'doom-rose-pine)`
-4. `doom/reload-theme` _(this doesn't seem to work for me though, you can restart emacs instead)_
+1. Clone or download this repo and cd into rose-pine-doom-emacs directory
+``` bash
+git clone https://github.com/donniebreve/rose-pine-doom-emacs.git
+cd rose-pine-doom-emacs
+```
+2. `make install` to copy the themes to `~/.config/.doom/themes/` 
+    - or manually place the theme files in `~/.config/doom/themes/`
+3. reload doom config `doom/reload`
+4. Set the theme 
+    - globally by updating the `config.el`
+        - `(setq doom-them 'doom-rose-pine)`
+    - or temporarily 
+        - `M-x` (Alt + X by default) `load-theme` and select the variant of rose-pine you want to try
+    
 
 # Themes provided
 1. Rosé Pine

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ All natural pine, faux fur and a bit of soho vibes for the classy minimalist.
 
 # How to install
 1. Clone or download this repo
-2. `make install` to copy the themes to `~/.doom.d/themes/`
+2. `make install` to copy the themes to `~/.config/.doom/themes/`
 3. Update your `config.el`
     - `(setq doom-theme 'doom-rose-pine)`
 4. `doom/reload-theme` _(this doesn't seem to work for me though, you can restart emacs instead)_


### PR DESCRIPTION
Previously doom use `~/.doom.d `directory for config files (which this repo uses) but has later been changed to `~/.config/doom`, so I changed the directories so `make install` works. 

PS: if you're not using emacs daemon there is no need to reload the emacs, theme works out of the box. If you are using emacs daemon the reloading theme or config works